### PR TITLE
Updates to auth token expiry for mobile logins

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,5 +1,7 @@
 const notificationTemplates = require('./notification-templates');
+const expires = require('./token-expiry');
 
 module.exports = {
   notificationTemplates,
+  expires,
 };

--- a/src/constants/token-expiry.js
+++ b/src/constants/token-expiry.js
@@ -1,0 +1,8 @@
+const moment = require('moment');
+
+module.exports = {
+  'inADay': moment.duration(1, 'day').asSeconds(),
+  'inAMonth': moment.duration(1, 'month').asSeconds(),
+  'inSixMonths': moment.duration(6, 'months').asSeconds(),
+  'inSevenMonths': moment.duration(7, 'months').asSeconds(),
+}

--- a/src/service/userDetails.js
+++ b/src/service/userDetails.js
@@ -495,7 +495,7 @@ class UserDetails {
       userId,
       authToken: token,
       refreshToken,
-      authTokenExpiry: moment().add(isMobilePlatform? 180 : 30, 'days'), // now.setDate(now.getDate() + 1),
+      authTokenExpiry: moment().add(isMobilePlatform? 180 : 1, 'days'),
       refreshTokenExpiry: moment().add(isMobilePlatform? (180 + 30) : 30, 'days'),
     });
   }


### PR DESCRIPTION
**Changes Proposed:**
- Following changes are done in `/users/login` and `/users/refresh-token` endpoint 
- Identify mobile requests through the header **_x-wstexchng-platform_** and set the auth token expiry to six months and refresh token expiry to seven months.
- If the header is not present (Ex: logins from the browser) then the auth token expiry is set to one day and refresh token expiry is set to one month.


